### PR TITLE
Use postgresql from the distribution instead of importing an internet-based repo

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 # Default version of Postgres server to install.
+# Ubuntu 22.04 has 14, RHEL8 has 13, 15, 16
 postgres_version: 14
 
 # Default listen_addresses of Postgres server

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Default version of Postgres server to install.
-postgres_version: 15
+postgres_version: 14
 
 # Default listen_addresses of Postgres server
 postgres_listen_addresses: '*'

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -12,34 +12,12 @@
     name: en_US.UTF-8
     state: present
 
-- name: Import PostgreSQL repository key
-  become: true
-  ansible.builtin.apt_key:
-    url: "{{ postgres_apt_key_url }}"
-    id: "{{ postgres_apt_key_id }}"
-    state: present
-  register: download_postgresql_key
-  until: download_postgresql_key is success
-  retries: 3
-  delay: 3
-
-- name: Register PostgreSQL repository
-  become: true
-  ansible.builtin.apt_repository:
-    repo: "{{ postgres_apt_repository_repo }}"
-    state: present
-    filename: pgdg
-  register: download_postgresql_repo
-  until: download_postgresql_repo is success
-  retries: 3
-  delay: 3
-
 - name: Install postgres packages
   become: true
   ansible.builtin.apt:
     name:
-      - postgresql-{{ postgres_version }}
-      - postgresql-contrib-{{ postgres_version }}
+      - postgresql
+      - postgresql-contrib
     state: present
     update_cache: true
     cache_valid_time: 3600

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -29,55 +29,40 @@
     - LANG=en_us.UTF-8
     - LANGUAGE=en_us.UTF-8
 
-- name: Import PostgreSQL GPG public key
+- name: Enable PostgreSQL module
   become: true
-  ansible.builtin.rpm_key:
-    key: "{{ postgres_rpmkey_url }}"
+  ansible.builtin.dnf:
+    name: '@postgresql:15'
     state: present
-  register: download_postgresql_key
-  until: download_postgresql_key is success
-  retries: 3
-  delay: 3
-
-- name: Install PostgreSQL repository
-  become: true
-  ansible.builtin.yum:
-    name: "{{ base }}/reporpms/EL-{{ version }}-x86_64/{{ repo_file_name }}"
-    state: present
-  vars:
-    base: https://download.postgresql.org/pub/repos/yum
-    version: "{{ ansible_distribution_major_version }}"
-    repo_file_name: pgdg-redhat-repo-latest.noarch.rpm
-  register: download_postgresql_repo
-  until: download_postgresql_repo is success
-  retries: 3
-  delay: 3
-
-- name: Disable PostgreSQL module
-  become: true
-  ansible.builtin.copy:
-    dest: /etc/dnf/modules.d/postgresql.module
-    owner: root
-    group: root
-    mode: '0644'
-    content: |
-      [postgresql]
-      name=postgresql
-      stream=
-      profiles=
-      state=disabled
   when:
     - ansible_os_family == 'RedHat'
     - ansible_distribution_major_version | int == 8
+
+# - name: Enable PostgreSQL module
+#   become: true
+#   ansible.builtin.copy:
+#     dest: /etc/dnf/modules.d/postgresql.module
+#     owner: root
+#     group: root
+#     mode: '0644'
+#     content: |
+#       [postgresql]
+#       name=postgresql
+#       stream=15
+#       profiles=server
+#       state=enabled
+#   when:
+#     - ansible_os_family == 'RedHat'
+#     - ansible_distribution_major_version | int == 8
 
 - name: Install PostgreSQL packages
   become: true
   ansible.builtin.yum:
     name:
-      - postgresql{{ postgres_server_pkg_version }}-server
-      - postgresql{{ postgres_server_pkg_version }}-contrib
+      - postgresql-server
+      - postgresql-contrib
     state: present
-  register: download_postgresql
-  until: download_postgresql is success
+  register: install_postgresql
+  until: install_postgresql is success
   retries: 3
   delay: 3

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -32,7 +32,7 @@
 - name: Enable PostgreSQL module
   become: true
   ansible.builtin.dnf:
-    name: '@postgresql:15'
+    name: "@postgresql:{{ postgres_version }}"
     state: present
   when:
     - ansible_os_family == 'RedHat'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -42,12 +42,6 @@
   environment:
     LC_ALL: "{{ postgres_locale }}"
 
-- name: Check FIPS status
-  ansible.builtin.command: cat /proc/sys/crypto/fips_enabled
-  register: _fips_enabled
-  ignore_errors: true
-  changed_when: false
-
 - name: Create private key (RSA, 4096 bits)
   community.crypto.openssl_privatekey:
     path: "{{ postgresql_data_dir }}/server.key"

--- a/templates/postgresql.conf.j2
+++ b/templates/postgresql.conf.j2
@@ -98,11 +98,7 @@ ssl_key_file = 'server.key'		# (change requires restart)
 ssl_ca_file = ''			# (change requires restart)
 ssl_crl_file = ''			# (change requires restart)
 
-{% if _fips_enabled.stdout | default('unknown', true) == '1' %}
 password_encryption = scram-sha-256
-{% else %}
-password_encryption = scram-sha-256
-{% endif %}
 #db_user_namespace = off
 #row_security = on
 

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -4,12 +4,3 @@ default_postgresql_config_path: /etc/postgresql/{{ postgres_version }}/main
 default_postgresql_data_dir: /var/lib/postgresql/{{ postgres_version }}/main
 default_postgresql_daemon: postgresql@{{ postgres_version }}-main
 default_postgresql_external_pid_file: /var/run/postgresql/{{ postgres_version }}-main.pid
-
-default_postgres_apt_key_id: '0x7FCC7D46ACCC4CF8'
-default_postgres_apt_key_url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
-default_postgres_apt_repository_repo: >-
-    {%- if ansible_distribution_release == 'bionic' -%}
-        deb https://apt-archive.postgresql.org/pub/repos/apt {{ ansible_distribution_release }}-pgdg main
-    {%- else -%}
-        deb https://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main
-    {%- endif -%}

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,6 +1,6 @@
 ---
-default_postgresql_bin_path: /usr/pgsql-{{ postgres_version }}/bin
-default_postgresql_config_path: /var/lib/pgsql/{{ postgres_version }}/data
-default_postgresql_data_dir: /var/lib/pgsql/{{ postgres_version }}/data
-default_postgresql_daemon: postgresql-{{ postgres_version }}.service
+default_postgresql_bin_path: /usr/bin
+default_postgresql_config_path: /var/lib/pgsql/data
+default_postgresql_data_dir: /var/lib/pgsql/data
+default_postgresql_daemon: postgresql.service
 default_postgresql_external_pid_file: /var/run/postgresql/{{ postgres_version }}-main.pid


### PR DESCRIPTION
For on-prem environments it's better to rely on the available package repositories for the OS.
RHEL8/AlmaLinux8/Rocky8 allow using Postgresql 13,15,16, Ubuntu 22.04 has 14.

Define `postgres_version` to your liking, or bring your own and set `postgres_enabled: false`.